### PR TITLE
Remove GenericLogic & GenericLogicFactory related artifacts from build & deploy scripts

### DIFF
--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -130,6 +130,7 @@ export const deployReserveLogicLibrary = async (verify?: boolean) =>
     verify
   );
 
+// TODO(vicfei): consider removing as no longer needed.
 export const deployGenericLogic = async (reserveLogic: Contract, verify?: boolean) => {
   const genericLogicArtifact = await readArtifact(eContractid.GenericLogic);
   const linkedGenericLogicByteCode = linkBytecode(genericLogicArtifact, {

--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -132,7 +132,6 @@ export const deployReserveLogicLibrary = async (verify?: boolean) =>
 
 export const deployGenericLogic = async (reserveLogic: Contract, verify?: boolean) => {
   const genericLogicArtifact = await readArtifact(eContractid.GenericLogic);
-
   const linkedGenericLogicByteCode = linkBytecode(genericLogicArtifact, {
     [eContractid.ReserveLogic]: reserveLogic.address,
   });

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -4,7 +4,6 @@ import {
   ATokensAndRatesHelperFactory,
   AaveOracleFactory,
   DefaultReserveInterestRateStrategyFactory,
-  GenericLogicFactory,
   InitializableAdminUpgradeabilityProxyFactory,
   LendingPoolAddressesProviderFactory,
   LendingPoolAddressesProviderRegistryFactory,
@@ -255,15 +254,6 @@ export const getReserveLogic = async (address?: tEthereumAddress) =>
     address ||
       (
         await getDb().get(`${eContractid.ReserveLogic}.${DRE.network.name}`).value()
-      ).address,
-    await getFirstSigner()
-  );
-
-export const getGenericLogic = async (address?: tEthereumAddress) =>
-  await GenericLogicFactory.connect(
-    address ||
-      (
-        await getDb().get(`${eContractid.GenericLogic}.${DRE.network.name}`).value()
       ).address,
     await getFirstSigner()
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,15 +312,15 @@
       }
     },
     "@ethereumjs/block": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.2.1.tgz",
-      "integrity": "sha512-FCxo5KwwULne2A2Yuae4iaGGqSsRjwzXOlDhGalOFiBbLfP3hE04RHaHGw4c8vh1PfOrLauwi0dQNUBkOG3zIA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.1.tgz",
+      "integrity": "sha512-o5d/zpGl4SdVfdTfrsq9ZgYMXddc0ucKMiFW5OphBCX+ep4xzYnSjboFcZXT2V/tcSBr84VrKWWp21CGVb3DGw==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "^2.2.0",
-        "@ethereumjs/tx": "^3.1.3",
-        "ethereumjs-util": "^7.0.10",
-        "merkle-patricia-tree": "^4.1.0"
+        "@ethereumjs/common": "^2.6.1",
+        "@ethereumjs/tx": "^3.5.0",
+        "ethereumjs-util": "^7.1.4",
+        "merkle-patricia-tree": "^4.2.3"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -389,18 +389,23 @@
           }
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
         },
         "level-codec": {
           "version": "9.0.2",
@@ -501,27 +506,20 @@
                 "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
               }
-            },
-            "immediate": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-              "dev": true
             }
           }
         },
         "merkle-patricia-tree": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz",
-          "integrity": "sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.3.tgz",
+          "integrity": "sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==",
           "dev": true,
           "requires": {
             "@types/levelup": "^4.3.0",
-            "ethereumjs-util": "^7.0.8",
+            "ethereumjs-util": "^7.1.4",
             "level-mem": "^5.0.1",
             "level-ws": "^2.0.0",
             "readable-stream": "^3.6.0",
-            "rlp": "^2.2.3",
             "semaphore-async-await": "^1.5.1"
           }
         },
@@ -534,19 +532,18 @@
       }
     },
     "@ethereumjs/blockchain": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.2.1.tgz",
-      "integrity": "sha512-+hshP2qSOOFsiYvZCbaDQFG7jYTWafE8sfBi+pAsdhAHfP7BN7VLyob7qoQISgwS1s7NTR4c4+2t/woU9ahItw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.1.tgz",
+      "integrity": "sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.2.0",
-        "@ethereumjs/common": "^2.2.0",
-        "@ethereumjs/ethash": "^1.0.0",
+        "@ethereumjs/block": "^3.6.0",
+        "@ethereumjs/common": "^2.6.0",
+        "@ethereumjs/ethash": "^1.1.0",
         "debug": "^2.2.0",
-        "ethereumjs-util": "^7.0.9",
+        "ethereumjs-util": "^7.1.3",
         "level-mem": "^5.0.1",
         "lru-cache": "^5.1.1",
-        "rlp": "^2.2.4",
         "semaphore-async-await": "^1.5.1"
       },
       "dependencies": {
@@ -625,18 +622,23 @@
           }
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
         },
         "level-codec": {
           "version": "9.0.2",
@@ -726,12 +728,6 @@
                 "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
               }
-            },
-            "immediate": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-              "dev": true
             }
           }
         },
@@ -750,13 +746,13 @@
       }
     },
     "@ethereumjs/common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.2.0.tgz",
-      "integrity": "sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.2.tgz",
+      "integrity": "sha512-vDwye5v0SVeuDky4MtKsu+ogkH2oFUV8pBKzH/eNBzT8oI91pKa8WyzDuYuxOQsgNgv5R34LfFDh2aaw3H4HbQ==",
       "dev": true,
       "requires": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.0.9"
+        "ethereumjs-util": "^7.1.4"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -775,30 +771,30 @@
           "dev": true
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
         }
       }
     },
     "@ethereumjs/ethash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.0.0.tgz",
-      "integrity": "sha512-iIqnGG6NMKesyOxv2YctB2guOVX18qMAWlj3QlZyrc+GqfzLqoihti+cVNQnyNxr7eYuPdqwLQOFuPe6g/uKjw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
+      "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
       "dev": true,
       "requires": {
+        "@ethereumjs/block": "^3.5.0",
         "@types/levelup": "^4.3.0",
         "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.0.7",
+        "ethereumjs-util": "^7.1.1",
         "miller-rabin": "^4.0.0"
       },
       "dependencies": {
@@ -827,29 +823,28 @@
           }
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
         }
       }
     },
     "@ethereumjs/tx": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.1.4.tgz",
-      "integrity": "sha512-6cJpmmjCpG5ZVN9NJYtWvmrEQcevw9DIR8hj2ca2PszD2fxbIFXky3Z37gpf8S6u0Npv09kG8It+G4xjydZVLg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.0.tgz",
+      "integrity": "sha512-/+ZNbnJhQhXC83Xuvy6I9k4jT5sXiV0tMR9C+AzSSpcCV64+NB8dTE1m3x98RYMqb8+TLYWA+HML4F5lfXTlJw==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "^2.2.0",
-        "ethereumjs-util": "^7.0.10"
+        "@ethereumjs/common": "^2.6.1",
+        "ethereumjs-util": "^7.1.4"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -868,40 +863,38 @@
           "dev": true
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
         }
       }
     },
     "@ethereumjs/vm": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.3.2.tgz",
-      "integrity": "sha512-QmCUQrW6xbhgEbQh9njue4kAJdM056C+ytBFUTF/kDYa3kNDm4Qxp9HUyTlt1OCSXvDhws0qqlh8+q+pmXpN7g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.7.1.tgz",
+      "integrity": "sha512-NiFm5FMaeDGZ9ojBL+Y9Y/xhW6S4Fgez+zPBM402T5kLsfeAR9mrRVckYhvkGVJ6FMwsY820CLjYP5OVwMjLTg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.2.1",
-        "@ethereumjs/blockchain": "^5.2.1",
-        "@ethereumjs/common": "^2.2.0",
-        "@ethereumjs/tx": "^3.1.3",
+        "@ethereumjs/block": "^3.6.1",
+        "@ethereumjs/blockchain": "^5.5.1",
+        "@ethereumjs/common": "^2.6.2",
+        "@ethereumjs/tx": "^3.5.0",
         "async-eventemitter": "^0.2.4",
         "core-js-pure": "^3.0.1",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.0.10",
+        "debug": "^4.3.3",
+        "ethereumjs-util": "^7.1.4",
         "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
-        "merkle-patricia-tree": "^4.1.0",
-        "rustbn.js": "~0.2.0",
-        "util.promisify": "^1.0.1"
+        "merkle-patricia-tree": "^4.2.3",
+        "rustbn.js": "~0.2.0"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -931,15 +924,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
           "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
         },
         "deferred-leveldown": {
           "version": "5.3.0",
@@ -979,18 +963,23 @@
           }
         },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
         },
         "level-codec": {
           "version": "9.0.2",
@@ -1091,35 +1080,22 @@
                 "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
               }
-            },
-            "immediate": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-              "dev": true
             }
           }
         },
         "merkle-patricia-tree": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz",
-          "integrity": "sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.3.tgz",
+          "integrity": "sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==",
           "dev": true,
           "requires": {
             "@types/levelup": "^4.3.0",
-            "ethereumjs-util": "^7.0.8",
+            "ethereumjs-util": "^7.1.4",
             "level-mem": "^5.0.1",
             "level-ws": "^2.0.0",
             "readable-stream": "^3.6.0",
-            "rlp": "^2.2.3",
             "semaphore-async-await": "^1.5.1"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "xtend": {
           "version": "4.0.2",
@@ -1554,6 +1530,36 @@
         "@ethersproject/strings": "^5.1.0"
       }
     },
+    "@metamask/eth-sig-util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.0.tgz",
+      "integrity": "sha512-LczOjjxY4A7XYloxzyxJIHONELmUxVZncpOLoClpEcTiebiVdM46KRPYXGuULro9oNNR2xdVx3yoKiQjdfWmoA==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -1651,13 +1657,13 @@
     "@nomiclabs/buidler-ethers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-ethers/-/buidler-ethers-2.0.0.tgz",
-      "integrity": "sha512-Lf5XLClEeWYo6jVrGAqGBAcKTOP6IAChAR4qcDS36BkQnWakoRKcoSbwhr2YmTNTRAvgDWTmjQYbV17udJ+Alw==",
+      "integrity": "sha1-+XLfmKXZ8y/Ol0dJ87qdlk8Ffyo=",
       "dev": true
     },
     "@nomiclabs/buidler-etherscan": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-etherscan/-/buidler-etherscan-2.1.0.tgz",
-      "integrity": "sha512-Rh1PGCtIVNU9zDSnLn6WlJDMBM9LXzkwNnzRFnTrMdA+Aa9nMVX7qwbAXG9pyIIsuqNH6MRfk7CDvi8aMoojng==",
+      "integrity": "sha1-zevJb3aD3pWGk1+0Ru/OeOmM+XM=",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.0.2",
@@ -1671,7 +1677,7 @@
     "@nomiclabs/buidler-waffle": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-waffle/-/buidler-waffle-2.0.0.tgz",
-      "integrity": "sha512-slGUjMmooIFehk1EMz+gSD07x6RVhp9aEHCmjk5MDm9FuV0+1IhPrk0DDl9ZKYlb5dgTRSWOqzIOXLXhnjmt0A==",
+      "integrity": "sha1-Ql3ZUomOY0lLaW+VVolpdWA2hP8=",
       "dev": true,
       "requires": {
         "@types/sinon-chai": "^3.2.3",
@@ -1737,7 +1743,7 @@
     "@openzeppelin/contracts": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.1.0.tgz",
-      "integrity": "sha512-dVXDnUKxrAKLzPdCRkz+N8qsVkK1XxJ6kk3zuI6zaQmcKxN7CkizoDP7lXxcs/Mi2I0mxceTRjJBqlzFffLJrQ==",
+      "integrity": "sha1-vOpFfviQafvlphf1CyW2qCcoldU=",
       "dev": true
     },
     "@resolver-engine/core": {
@@ -1952,7 +1958,7 @@
     "@tenderly/hardhat-tenderly": {
       "version": "1.1.0-beta.5",
       "resolved": "https://registry.npmjs.org/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.1.0-beta.5.tgz",
-      "integrity": "sha512-NecF6ewefpDyIF/mz0kTZGlPMa+ri/LOAPPqmyRA/oGEZ19BLM0sHdJFObTv8kJnxIJZBHpTkUaeDPp8KcpZsg==",
+      "integrity": "sha1-+Y043gIADFPHDdq4VkLN/6QGhLM=",
       "dev": true,
       "requires": {
         "@nomiclabs/hardhat-ethers": "^2.0.1",
@@ -1965,7 +1971,7 @@
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -1977,7 +1983,7 @@
         "js-yaml": {
           "version": "3.14.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -2129,7 +2135,7 @@
     "@typechain/ethers-v5": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
-      "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
+      "integrity": "sha1-zTyhWQJA1YfKMB9MAptnv8zQiBA=",
       "dev": true,
       "requires": {
         "ethers": "^5.0.2"
@@ -2138,13 +2144,13 @@
     "@typechain/truffle-v4": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@typechain/truffle-v4/-/truffle-v4-2.0.2.tgz",
-      "integrity": "sha512-YoJAzgQZeark7lwInLnJ3u14JO980W5mVzFUkZny40+/WSPlox5Sa5IWLkULrgwkEWoiLA2sTpJ2tE7nCtSC2Q==",
+      "integrity": "sha1-Q9UNFcSeoZdeJbUkSK1kLA7qUa0=",
       "dev": true
     },
     "@typechain/truffle-v5": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@typechain/truffle-v5/-/truffle-v5-2.0.2.tgz",
-      "integrity": "sha512-g4N2kfol1S3g/QUkmpzukCGZiKWUdXsSms1be/+W4+R0DPMz1Q/76tY+C6bD7G/KeLhkiDKcnZFmNVNcAgjIfQ==",
+      "integrity": "sha1-cJp4/7Eg9SxpOBj+py4LDRRsNFQ=",
       "dev": true
     },
     "@typechain/web3-v1": {
@@ -2154,9 +2160,9 @@
       "dev": true
     },
     "@types/abstract-leveldown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
-      "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+      "integrity": "sha512-q5veSX6zjUy/DlDhR4Y4cU0k2Ar+DT2LUraP00T19WLmTO6Se1djepCCaqU6nQrwcJ5Hyo/CWqxTzrrFg8eqbQ==",
       "dev": true
     },
     "@types/bn.js": {
@@ -2171,7 +2177,7 @@
     "@types/chai": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "integrity": "sha1-02FNbF9QAUI1jm7SThvxZldTbFA=",
       "dev": true
     },
     "@types/concat-stream": {
@@ -2202,13 +2208,20 @@
         "@types/node": "*"
       }
     },
+    "@types/level-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
+      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==",
+      "dev": true
+    },
     "@types/levelup": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.1.tgz",
-      "integrity": "sha512-n//PeTpbHLjMLTIgW5B/g06W/6iuTBHuvUka2nFL9APMSVMNe2r4enADfu3CIE9IyV9E+uquf9OEQQqrDeg24A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
+      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
       "dev": true,
       "requires": {
         "@types/abstract-leveldown": "*",
+        "@types/level-errors": "*",
         "@types/node": "*"
       }
     },
@@ -2221,7 +2234,7 @@
     "@types/lowdb": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/lowdb/-/lowdb-1.0.9.tgz",
-      "integrity": "sha512-LBRG5EPXFOJDoJc9jACstMhtMP+u+UkPYllBeGQXXKiaHc+uzJs9+/Aynb/5KkX33DtrIiKyzNVTPQc/4RcD6A==",
+      "integrity": "sha1-H2wn33LdHGRSLMmkVmeW0t0FjTg=",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -2251,13 +2264,13 @@
     "@types/mocha": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "integrity": "sha1-sX8Wz5M1l+ENbXjq4yUeaSzosM4=",
       "dev": true
     },
     "@types/node": {
       "version": "14.0.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
-      "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==",
+      "integrity": "sha1-PQOs07NBTPZ/r5ma7RFoLtEh8is=",
       "dev": true
     },
     "@types/node-fetch": {
@@ -2363,6 +2376,12 @@
         "@types/underscore": "*"
       }
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -2436,6 +2455,16 @@
       "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -2518,6 +2547,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.2",
@@ -2756,7 +2791,7 @@
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "integrity": "sha1-gFiA+Eoym16sbny2+CdLbYK98HU=",
       "dev": true
     },
     "binary-extensions": {
@@ -3129,7 +3164,7 @@
     "buidler-typechain": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buidler-typechain/-/buidler-typechain-0.1.1.tgz",
-      "integrity": "sha512-UXS6m0MUzomDWFfd6Jivbz/wmNZo4dpW/Qa6Lq89qhS/qms/j1haJqlMxsDu+tCi8i/JH/IZtFkiEmEQ1PgmhA==",
+      "integrity": "sha1-mNWz6iIqpGp5LA5ZGriUqktlwC4=",
       "dev": true
     },
     "builtin-modules": {
@@ -3228,7 +3263,7 @@
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -3242,7 +3277,7 @@
     "chai-bignumber": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chai-bignumber/-/chai-bignumber-3.0.0.tgz",
-      "integrity": "sha512-SubOtaSI2AILWTWe2j0c6i2yFT/f9J6UBjeVGDuwDiPLkF/U5+/eTWUE3sbCZ1KgcPF6UJsDVYbIxaYA097MQA==",
+      "integrity": "sha1-6Qzx9Gg1W7sRqazQUSIlhs0mSKk=",
       "dev": true
     },
     "chai-bn": {
@@ -3284,19 +3319,19 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -3350,6 +3385,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cli-table3": {
@@ -3649,13 +3690,13 @@
       }
     },
     "crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.1.tgz",
+      "integrity": "sha512-Dn/xm/1vFFgs3nfrpEVScHoIslO9NZRITWGz/1E/St6u4xw99vfZzVkW0OSnzx2h9egej9xwMCEut6sqwokM/w==",
       "dev": true,
       "requires": {
         "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
+        "printj": "~1.3.1"
       }
     },
     "create-ecdh": {
@@ -3773,9 +3814,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -4173,7 +4214,7 @@
     "dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "integrity": "sha1-Bhr2ZNGff02PxuT/m1hM4jety4s=",
       "dev": true
     },
     "download": {
@@ -4420,6 +4461,12 @@
         "d": "^1.0.1",
         "ext": "^1.1.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4672,7 +4719,7 @@
     "eth-sig-util": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.3.tgz",
-      "integrity": "sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==",
+      "integrity": "sha1-aTgwizgibgswhUNUdJALAwNqvL4=",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -4696,7 +4743,7 @@
             "ethereumjs-util": {
               "version": "4.5.1",
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
-              "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
+              "integrity": "sha1-9L+bO1FaSE48yHgdYdnZgPfIO9A=",
               "dev": true,
               "requires": {
                 "bn.js": "^4.8.0",
@@ -4711,7 +4758,7 @@
         "ethereumjs-util": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "integrity": "sha1-qDPw5fyn5bNhOE3HYwGnIfU3v2U=",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
@@ -5019,7 +5066,7 @@
     "ethereumjs-util": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.2.tgz",
-      "integrity": "sha512-ATAP02eJLpAlWGfiKQddNrRfZpwXiTFhRN2EM/yLXMCdBW/xjKYblNKcx8GLzzrjXg0ymotck+lam1nuV90arQ==",
+      "integrity": "sha1-fg2fzSJezm5J7k6mVgnRJHFfHRU=",
       "dev": true,
       "requires": {
         "@types/bn.js": "^4.11.3",
@@ -5034,7 +5081,7 @@
         "bn.js": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
           "dev": true
         }
       }
@@ -15412,9 +15459,9 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15553,22 +15600,25 @@
       }
     },
     "hardhat": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.3.0.tgz",
-      "integrity": "sha512-nc4ro2bM4wPaA6/0Y22o5F5QrifQk2KCyPUUKLPUeFFZoGNGYB8vmeW/k9gV9DdMukdWTzfYlKc2Jn4bfb6tDQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.9.1.tgz",
+      "integrity": "sha512-q0AkYXV7R26RzyAkHGQRhhQjk508pseVvH3wSwZwwPUbvA+tjl0vMIrD4aFQDonRXkrnXX4+5KglozzjSd0//Q==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.2.1",
-        "@ethereumjs/blockchain": "^5.2.1",
-        "@ethereumjs/common": "^2.2.0",
-        "@ethereumjs/tx": "^3.1.3",
-        "@ethereumjs/vm": "^5.3.2",
+        "@ethereumjs/block": "^3.6.0",
+        "@ethereumjs/blockchain": "^5.5.0",
+        "@ethereumjs/common": "^2.6.0",
+        "@ethereumjs/tx": "^3.4.0",
+        "@ethereumjs/vm": "^5.6.0",
+        "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
         "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.11.0",
+        "@solidity-parser/parser": "^0.14.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
@@ -15576,10 +15626,9 @@
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
         "ethereum-cryptography": "^0.1.2",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-util": "^7.1.3",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
@@ -15587,10 +15636,10 @@
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
         "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^4.1.0",
+        "merkle-patricia-tree": "^4.2.2",
         "mnemonist": "^0.38.0",
-        "mocha": "^7.1.2",
-        "node-fetch": "^2.6.0",
+        "mocha": "^9.2.0",
+        "p-map": "^4.0.0",
         "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
@@ -15601,15 +15650,19 @@
         "stacktrace-parser": "^0.1.10",
         "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
-        "uuid": "^3.3.2",
-        "ws": "^7.2.1"
+        "undici": "^4.14.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.4.6"
       },
       "dependencies": {
         "@solidity-parser/parser": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.11.1.tgz",
-          "integrity": "sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==",
-          "dev": true
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
+          "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
+          "dev": true,
+          "requires": {
+            "antlr4ts": "^0.5.0-alpha.4"
+          }
         },
         "@types/bn.js": {
           "version": "5.1.0",
@@ -15633,16 +15686,75 @@
             "xtend": "~4.0.0"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
         "bn.js": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
           "dev": true
         },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "commander": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
           "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
         },
         "deferred-leveldown": {
@@ -15670,6 +15782,18 @@
             }
           }
         },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "encoding-down": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
@@ -15682,18 +15806,62 @@
             "level-errors": "^2.0.0"
           }
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "ethereumjs-util": {
-          "version": "7.0.10",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-          "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
           "dev": true,
           "requires": {
             "@types/bn.js": "^5.1.0",
             "bn.js": "^5.1.2",
             "create-hash": "^1.1.2",
             "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
+          }
+        },
+        "flat": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+          "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
           }
         },
         "jsonfile": {
@@ -15778,6 +15946,46 @@
             "xtend": "~4.0.0"
           }
         },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
         "memdown": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
@@ -15804,29 +16012,105 @@
                 "level-supports": "~1.0.0",
                 "xtend": "~4.0.0"
               }
-            },
-            "immediate": {
-              "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-              "dev": true
             }
           }
         },
         "merkle-patricia-tree": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz",
-          "integrity": "sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.3.tgz",
+          "integrity": "sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==",
           "dev": true,
           "requires": {
             "@types/levelup": "^4.3.0",
-            "ethereumjs-util": "^7.0.8",
+            "ethereumjs-util": "^7.1.4",
             "level-mem": "^5.0.1",
             "level-ws": "^2.0.0",
             "readable-stream": "^3.6.0",
-            "rlp": "^2.2.3",
             "semaphore-async-await": "^1.5.1"
           }
+        },
+        "minimatch": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mocha": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+          "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+          "dev": true,
+          "requires": {
+            "@ungap/promise-all-settled": "1.1.2",
+            "ansi-colors": "4.1.1",
+            "browser-stdout": "1.3.1",
+            "chokidar": "3.5.3",
+            "debug": "4.3.3",
+            "diff": "5.0.0",
+            "escape-string-regexp": "4.0.0",
+            "find-up": "5.0.0",
+            "glob": "7.2.0",
+            "growl": "1.10.5",
+            "he": "1.2.0",
+            "js-yaml": "4.1.0",
+            "log-symbols": "4.1.0",
+            "minimatch": "4.2.1",
+            "ms": "2.1.3",
+            "nanoid": "3.3.1",
+            "serialize-javascript": "6.0.0",
+            "strip-json-comments": "3.1.1",
+            "supports-color": "8.1.1",
+            "which": "2.0.2",
+            "workerpool": "6.2.0",
+            "yargs": "16.2.0",
+            "yargs-parser": "20.2.4",
+            "yargs-unparser": "2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         },
         "resolve": {
           "version": "1.17.0",
@@ -15884,6 +16168,41 @@
             }
           }
         },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15893,11 +16212,76 @@
             "os-tmpdir": "~1.0.2"
           }
         },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
         "xtend": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
           "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
           "dev": true
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        },
+        "yargs-unparser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+          "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^6.0.0",
+            "decamelize": "^4.0.0",
+            "flat": "^5.0.2",
+            "is-plain-obj": "^2.1.0"
+          }
         }
       }
     },
@@ -15914,7 +16298,7 @@
     "hardhat-typechain": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/hardhat-typechain/-/hardhat-typechain-0.3.5.tgz",
-      "integrity": "sha512-w9lm8sxqTJACY+V7vijiH+NkPExnmtiQEjsV9JKD1KgMdVk2q8y+RhvU/c4B7+7b1+HylRUCxpOIvFuB3rE4+w==",
+      "integrity": "sha1-jlBhap2jSLM70AEWjI/anGa3tK8=",
       "dev": true
     },
     "has": {
@@ -16081,7 +16465,7 @@
     "husky": {
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
-      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "integrity": "sha1-MRRAYL6WP9aFDlzI8Bmh3+GUKW0=",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -16206,6 +16590,12 @@
           "dev": true
         }
       }
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -16499,6 +16889,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-url": {
@@ -17079,7 +17475,7 @@
     "lowdb": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
-      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
+      "integrity": "sha1-UkO+ayJ4bMzjDlDJoz6sNrIMgGQ=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.3",
@@ -17138,9 +17534,9 @@
       "dev": true
     },
     "mcl-wasm": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.7.tgz",
-      "integrity": "sha512-jDGiCQA++5hX37gdH6RDZ3ZsA0raet7xyY/R5itj5cbcdf4Gvw+YyxWX/ZZ0Z2UPxJiw1ktRsCJZzpnqlQILdw==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
+      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
       "dev": true
     },
     "md5.js": {
@@ -17712,6 +18108,12 @@
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -18079,6 +18481,15 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-timeout": {
@@ -18506,7 +18917,7 @@
     "pretty-quick": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.2.tgz",
-      "integrity": "sha512-aLb6vtOTEfJDwi1w+MBTeE20GwPVUYyn6IqNg6TtGpiOB1W3y6vKcsGFjqGeaaEtQgMLSPXTWONqh33UBuwG8A==",
+      "integrity": "sha1-TkTWSJ7VE+8RG+5QH2NojYVFhOY=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -18520,7 +18931,7 @@
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -18569,9 +18980,9 @@
       }
     },
     "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.3.1.tgz",
+      "integrity": "sha512-GA3TdL8szPK4AQ2YnOe/b+Y1jUFwmmGMMK/qbY7VcE3Z7FU8JstbKiKRzO6CIiAKPhTO8m01NoQ0V5f3jc4OGg==",
       "dev": true
     },
     "process": {
@@ -18776,9 +19187,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -19149,6 +19560,15 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
@@ -19906,7 +20326,7 @@
     "temp-hardhat-etherscan": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/temp-hardhat-etherscan/-/temp-hardhat-etherscan-2.0.2.tgz",
-      "integrity": "sha512-q9+OMPXlsXZ+2fnF+Xmvv0J9vNJChwOXVGJIATiDJr7Qe8LzTwgs55C4l4NKMWPLe4PE9UjcQMVntRfXGTF9vA==",
+      "integrity": "sha1-vP5zW1l1e5NutRhNUUwUQxpw7/s=",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.0.2",
@@ -20069,7 +20489,7 @@
     "ts-generator": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ts-generator/-/ts-generator-0.1.1.tgz",
-      "integrity": "sha512-N+ahhZxTLYu1HNTQetwWcx3so8hcYbkKBHTr4b4/YgObFTIKkOSSsaa+nal12w8mfrJAyzJfETXawbNjSfP2gQ==",
+      "integrity": "sha1-r0by+4im2x+XhZd+lZDnvNeSIKs=",
       "dev": true,
       "requires": {
         "@types/mkdirp": "^0.5.2",
@@ -20086,7 +20506,7 @@
         "ts-essentials": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
-          "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==",
+          "integrity": "sha1-zjtdreX12Xz2mInBG/fS2oVVsVo=",
           "dev": true
         }
       }
@@ -20094,7 +20514,7 @@
     "ts-node": {
       "version": "8.10.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "integrity": "sha1-7uA3ZGM7EjTd03+NuewQt17H+40=",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -20107,7 +20527,7 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
           "dev": true
         }
       }
@@ -20121,7 +20541,7 @@
     "tslint": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
-      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+      "integrity": "sha1-XCOy7MwySH1VI706Rw6aoxeJ2QQ=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -20142,13 +20562,13 @@
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
@@ -20156,13 +20576,13 @@
     "tslint-config-prettier": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
-      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "integrity": "sha1-dfFAvelH012PDSOODr+AnWRZLDc=",
       "dev": true
     },
     "tslint-plugin-prettier": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.3.0.tgz",
-      "integrity": "sha512-F9e4K03yc9xuvv+A0v1EmjcnDwpz8SpCD8HzqSDe0eyg34cBinwn9JjmnnRrNAs4HdleRQj7qijp+P/JTxt4vA==",
+      "integrity": "sha1-c/5xv58DhCrEjBBBIsqbHeAS7PQ=",
       "dev": true,
       "requires": {
         "eslint-plugin-prettier": "^2.2.0",
@@ -20246,7 +20666,7 @@
     "typechain": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/typechain/-/typechain-4.0.3.tgz",
-      "integrity": "sha512-tmoHQeXZWHxIdeLK+i6dU0CU0vOd9Cndr3jFTZIMzak5/YpFZ8XoiYpTZcngygGBqZo+Z1EUmttLbW9KkFZLgQ==",
+      "integrity": "sha1-6PzWyYRnaFjGTu6xVep4OhC3N3k=",
       "dev": true,
       "requires": {
         "command-line-args": "^4.0.7",
@@ -20332,6 +20752,12 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "dev": true
+    },
+    "undici": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.1.tgz",
+      "integrity": "sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==",
       "dev": true
     },
     "unfetch": {
@@ -21335,6 +21761,12 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -21380,9 +21812,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true
     },
     "xhr": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "ethereumjs-util": "7.0.2",
     "ethers": "^5.0.19",
     "globby": "^11.0.1",
-    "hardhat": "^2.2.0",
+    "hardhat": "^2.9.1",
     "hardhat-gas-reporter": "^1.0.0",
     "hardhat-typechain": "^0.3.3",
     "husky": "^4.2.5",


### PR DESCRIPTION
Previous change #1 (AddedHealthFactorLiquidationThresholdManager) removed `HEALTH_FACTOR_LIQUIDATION_THRESHOLD` public constant from Library contract `GenericLogic`. Due to the nature of Library Contract used for and not necessarily need to be deployed [see article](https://cryptomarketpool.com/libraries-in-solidity/),  resulting in no ABI defined and no typechain generated (after compilation, observe `artifacts/contracts/protocol/libraries/logic/GenericLogic.sol/GenericLogic.json` has no ABI defined and in `types/` no `GenericLogic*.ts` files created. Due to deployment scripts such as `contracts-deployment.ts` and `contracts-getters.ts` importing such `GenericLogic*.ts` files, commands such as `yarn hardhat typechain` or other deployment scripts fail.

Note: `artifacts/` folder is only used for deployment to an external network. For hardhat network, fetching artifact does not rely on `artifacts/` folder. For detail, see: `helpers/contracts-deployment.ts:readArtifact`.
This change fixes the above issue by removing dependencies on GenericLogic in various deployment scripts