### PR TITLE
Removed --skip-registry from aave:kovan:dev:migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ docker-compose exec contracts-env bash
 # A new Bash terminal is prompted, connected to the container.
 # You can run these commands for deployment with different arguments.
 
+# Deployment (dev) deployment with no contract verification:
+npm run aave:kovan:dev:migration
+
 # Deployment with registry deployment and contract verification:
 npm run aave:kovan:full:migration:add-registry:verify
 
@@ -101,9 +104,6 @@ npm run aave:kovan:full:migration:add-registry
 
 # Deployment with no registry deployment and no contract verification:
 npm run aave:kovan:full:migration
-
-# Deployment (dev) with no registry deployment:
-npm run aave:kovan:dev:migration
 ```
 Note that for the above *full* deployment, both the first and second accounts will need to be funded. For detail, see:
 `markets/aave/commons.ts`, where `EmergencyAdminIndex, PoolAdminIndex` represent the account indices for contract

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "aave:evm:dev:migration": "npm run compile && hardhat aave:dev",
     "aave:docker:full:migration": "npm run compile && npm run hardhat:docker -- aave:mainnet --skip-registry",
     "aave:kovan:full:migration": "npm run compile && npm run hardhat:kovan -- aave:mainnet --skip-registry",
-    "aave:kovan:dev:migration": "npm run compile && npm run hardhat:kovan -- aave:dev --skip-registry",
+    "aave:kovan:dev:migration": "npm run compile && npm run hardhat:kovan -- aave:dev",
     "matic:mumbai:full:migration": "npm run compile && npm run hardhat:mumbai sidechain:mainnet -- --pool Matic --skip-registry",
     "matic:matic:full:migration": "npm run compile && npm run hardhat:matic sidechain:mainnet -- --pool Matic --skip-registry",
     "avalanche:fuji:full:migration": "npm run compile && npm run hardhat:fuji avalanche:mainnet -- --pool Avalanche",


### PR DESCRIPTION
Removed --skip-registry from aave:kovan:dev:migration as dev scripts does not have a parameter for skipping registry, only has a parameter for contract verification. For detail see: https://github.com/ormi-fi/protocol-v2/blob/main/tasks/migrations/aave.dev.ts